### PR TITLE
feat: Adds the option to pass amount of dummy data as command argument

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,19 +1,24 @@
 const dummyjson = require('dummy-json');
 const fs = require('fs');
-const amount = 200;
-const template = (amount) => `{
-    "data":[
-        {{#repeat ${amount}}}
-        {
-            "name": "{{lorem 3}}",
-            "image": "https://source.unsplash.com/user/erondu/2{{int 10 99}}x3{{int 10 99}}",
-            "hair": "{{color}}",
-            "skin": "{{color}}"
-        }
-        {{/repeat}}
-    ]
+
+if (process.argv[2]) {
+    const amount = process.argv[2];
+    const template = (amount) => `{
+        "data":[
+            {{#repeat ${amount}}}
+            {
+                "name": "{{lorem 3}}",
+                "image": "https://source.unsplash.com/user/erondu/2{{int 10 99}}x3{{int 10 99}}",
+                "hair": "{{color}}",
+                "skin": "{{color}}"
+            }
+            {{/repeat}}
+        ]
+    }
+    `;
+    fs.writeFile(`Dummy-${amount}.json`,dummyjson.parse(template(amount)), () => {
+        console.log('Dummy file created');
+    });
+} else {
+    console.log('You need to pass the amount of dummy data as an argument: e.g. node src/index.js 200');
 }
-`;
-fs.writeFile(`Dummy-${amount}.json`,dummyjson.parse(template(amount)), () => {
-    console.log('Dummy file created');
-})


### PR DESCRIPTION
* Adds the possibility to pass the amount of dummy data wanted via command line arguments
_example: `node index.js 100` - Creates dummy_100.json file with 100 samples of dummy data